### PR TITLE
Add one-dark theme

### DIFF
--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -22,3 +22,4 @@
 @use "themes/neupink";
 @use "themes/night-sky";
 @use "themes/neucrystalgrape";
+@use "themes/one-dark";

--- a/src/scss/themes/_one-dark.scss
+++ b/src/scss/themes/_one-dark.scss
@@ -1,0 +1,18 @@
+@use "../utils/theme";
+
+$bgColor: #263238;
+$textColor: #b0bec5;
+$borderColor: #1e272c;
+
+@include theme.create-theme(
+  "one-dark",
+  $bgColor,
+  $textColor,
+  $borderColor,
+  $bgColor,
+  lighten($textColor, 6%),
+  lighten($bgColor, 3%),
+  $bgColor,
+  $textColor,
+  lighten($bgColor, 3%)
+);

--- a/src/ts/Editor.ts
+++ b/src/ts/Editor.ts
@@ -48,6 +48,7 @@ export class Editor {
         this.addTheme("neu-pink");
         this.addTheme("night-sky");
         this.addTheme("neu-crystalgrape");
+        this.addTheme("one-dark");
 
         this.root = EditorGroup.createRoot(`${id}_editor`, name, data, document.body, this.themeSelect);
 


### PR DESCRIPTION
### Related Issue: #36 
Hello there! 😊 

I added my current version of the classic atom theme [one-dark](https://github.com/atom/atom/tree/master/packages/one-dark-syntax).
I tweaked it a bit basing on my IDE preferences.

Let me know if you need any change!

Thanks for the opportunity!
Happy Hacktoberfest!