### PR TITLE
Add gameboy theme

### DIFF
--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -24,3 +24,4 @@
 @use "themes/neucrystalgrape";
 @use "themes/one-dark";
 @use "themes/neugreysun";
+@use "themes/gameboy";

--- a/src/scss/themes/_gameboy.scss
+++ b/src/scss/themes/_gameboy.scss
@@ -1,0 +1,18 @@
+@use "../utils/theme";
+
+$bgColor: #8aad00;
+$textColor: #0d380d;
+$borderColor: #2e632d;
+
+@include theme.create-theme(
+  "gameboy",
+  $bgColor,
+  $textColor,
+  $borderColor,
+  rgba(0, 0, 0, 0.03),
+  $textColor,
+  rgba(0, 0, 0, 0.125),
+  $bgColor,
+  $textColor,
+  darken($bgColor, 100%)
+);

--- a/src/ts/Editor.ts
+++ b/src/ts/Editor.ts
@@ -50,6 +50,7 @@ export class Editor {
         this.addTheme("neu-crystalgrape");
         this.addTheme("one-dark");
         this.addTheme("neu-greysun");
+        this.addTheme("gameboy");
 
         this.root = EditorGroup.createRoot(`${id}_editor`, name, data, document.body, this.themeSelect);
 


### PR DESCRIPTION
**Issue #36**

Add a simple new "gameboy" theme.

<img width="307" alt="Screenshot 2020-10-20 at 01 58 54" src="https://user-images.githubusercontent.com/99196/96524604-0938eb00-1279-11eb-93a0-fa2af5842182.png">

This is my first open contribution, and It was a fun and well documented first issue! 
Happy hacktoberfest!
